### PR TITLE
Removes target from global config variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: go
 
+go:
+- 1.15.x
+
 before_script:
 - go get golang.org/x/tools/cmd/cover
 - go get github.com/mattn/goveralls

--- a/testdata/check_target.sh
+++ b/testdata/check_target.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if [[ -z $TARGET ]]; then
+  echo "TARGET is undefined"
+  exit 1
+else
+  echo "TARGET is ${TARGET}"
+fi


### PR DESCRIPTION
Currently, there is a bug in the use of the `Target` element  of the `Script` struct. Since the global `Config` is a slice of `Script` pointers, every request uses the same set of values, yet every request would modify the `Target` element, causing undefined behavior.

This PR removes `Target` from the `Script` struct, and instead passed it around as a parameter to `runScripts` and `runScript`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/script_exporter/6)
<!-- Reviewable:end -->
